### PR TITLE
Change install to use README.md vs .rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-with open("README.rst") as fh:
+with open("README.md") as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
`qiime-studio` python install broke after removing README.rst, changed to use the .md version.