### PR TITLE
MAINT: Update to use new framework API

### DIFF
--- a/qiime_studio/api/v1.py
+++ b/qiime_studio/api/v1.py
@@ -33,21 +33,21 @@ def api_workflows(plugin_name):
         workflows_dict[key]['name'] = key
         workflows_dict[key]['info'] = "Produces: {}".format(
             ", ".join([
-                repr(type)
-                for type in value.signature.output_artifacts.values()
+                repr(type_[0])
+                for type_ in value.signature.outputs.values()
             ])
         )
         workflows_dict[key]['description'] = value.signature.name
         workflows_dict[key]['input_artifacts'] = [
-            {'name': name, 'type': repr(type)}
-            for name, type in value.signature.input_artifacts.items()
+            {'name': name, 'type': repr(type_[0])}
+            for name, type_ in value.signature.inputs.items()
         ]
         workflows_dict[key]['input_parameters'] = [
-            {'name': name, 'type': repr(type)}
-            for name, type in value.signature.input_parameters.items()
+            {'name': name, 'type': repr(type_[0])}
+            for name, type_ in value.signature.parameters.items()
         ]
         workflows_dict[key]['output_artifacts'] = [
-            {'name': name, 'type': repr(type)}
-            for name, type in value.signature.output_artifacts.items()
+            {'name': name, 'type': repr(type_[0])}
+            for name, type_ in value.signature.outputs.items()
         ]
     return jsonify({"workflows": workflows_dict})


### PR DESCRIPTION
Minor changes, updated local variable `type` to `type_` (doesn't mask the `type` builtin this way).

`Signature`'s mappings now map to a tuple `(SemanticType, ViewType)` which is why we index zero.