### PR TITLE
Add sorting to prevent refresh shuffling

### DIFF
--- a/app/js/components/Workflows.jsx
+++ b/app/js/components/Workflows.jsx
@@ -4,7 +4,7 @@ import Workflow from './Workflow';
 
 const Workflows = ({ plugin, openWorkflow }) => (
     <div>
-        { plugin.workflows.map(workflow => (
+        { plugin.workflows.sort((a, b) => a.name > b.name).map(workflow => (
             <Workflow
                 key={workflow.name}
                 flow={workflow}

--- a/app/js/containers/PluginsList.js
+++ b/app/js/containers/PluginsList.js
@@ -4,7 +4,8 @@ import Plugins from '../components/Plugins.jsx';
 
 const mapStateToProps = (state) => {
     return {
-        plugins: state.plugins.filter(plugin => plugin.workflows.length !== 0)
+        plugins: (state.plugins.filter(plugin => plugin.workflows.length !== 0))
+                    .sort((a, b) => a.name > b.name)
     };
 };
 


### PR DESCRIPTION
Sort plugins and workflows alphabetically by name. Stops the bouncing around issue when refreshing workflow information.

Fixes #44