### PR TITLE
BUG: Fix action disabling when type not found

### DIFF
--- a/app/js/actions/plugins.js
+++ b/app/js/actions/plugins.js
@@ -57,6 +57,7 @@ export const loadPlugins = () => {
                 ({ plugin: { name, methodsURI, visualizersURI } }) => {
                     dispatch(loadMethods(name, methodsURI));
                     dispatch(loadVisualizers(name, visualizersURI));
-                }));
+                }))
+        .then(() => actions.checkTypes());
     };
 };


### PR DESCRIPTION
This was causing unavailable actions to be displayed as available because the filter would fail out if a type wasn't present.