### PR TITLE
MAINT: Add license header to all files

### DIFF
--- a/app/css/JobHistory.css
+++ b/app/css/JobHistory.css
@@ -1,3 +1,13 @@
+/*
+----------------------------------------------------------------------------
+Copyright (c) 2016--, QIIME development team.
+
+Distributed under the terms of the Modified BSD License.
+
+The full license is in the file LICENSE, distributed with this software.
+----------------------------------------------------------------------------
+*/
+
 .table {
     table-layout: fixed;
     word-wrap: break-word;

--- a/app/css/JobRunning.css
+++ b/app/css/JobRunning.css
@@ -1,4 +1,14 @@
 /*
+----------------------------------------------------------------------------
+Copyright (c) 2016--, QIIME development team.
+
+Distributed under the terms of the Modified BSD License.
+
+The full license is in the file LICENSE, distributed with this software.
+----------------------------------------------------------------------------
+*/
+
+/*
 A Pen created at CodePen.io. You can find this one at
 http://codepen.io/albebonv/pen/DehCH.
 

--- a/app/css/Loading.css
+++ b/app/css/Loading.css
@@ -1,3 +1,13 @@
+/*
+----------------------------------------------------------------------------
+Copyright (c) 2016--, QIIME development team.
+
+Distributed under the terms of the Modified BSD License.
+
+The full license is in the file LICENSE, distributed with this software.
+----------------------------------------------------------------------------
+*/
+
 @keyframes spin {
     from { transform: rotate(0); }
     to { transform: rotate(360deg); }

--- a/app/css/Visualization.css
+++ b/app/css/Visualization.css
@@ -1,3 +1,13 @@
+/*
+----------------------------------------------------------------------------
+Copyright (c) 2016--, QIIME development team.
+
+Distributed under the terms of the Modified BSD License.
+
+The full license is in the file LICENSE, distributed with this software.
+----------------------------------------------------------------------------
+*/
+
 .webview {
     min-height: 100vh;
 }

--- a/app/css/hljs.css
+++ b/app/css/hljs.css
@@ -1,0 +1,88 @@
+/*
+Description: Foundation 4 docs style for highlight.js
+Author: Dan Allen <dan.j.allen@gmail.com>
+Website: http://foundation.zurb.com/docs/
+Version: 1.0
+Date: 2013-04-02
+*/
+
+.hljs {
+    display: block;
+    overflow-x: auto;
+    padding: 0.5em;
+    color: black;
+}
+
+.hljs-link,
+.hljs-emphasis,
+.hljs-attribute,
+.hljs-addition {
+    color: #070;
+}
+
+.hljs-emphasis {
+    font-style: italic;
+}
+
+.hljs-strong,
+.hljs-string,
+.hljs-deletion {
+    color: #d14;
+}
+
+.hljs-strong {
+    font-weight: bold;
+}
+
+.hljs-quote,
+.hljs-comment {
+    color: #998;
+    font-style: italic;
+}
+
+.hljs-section,
+.hljs-title {
+    color: #900;
+}
+
+.hljs-class .hljs-title,
+.hljs-type {
+    color: #458;
+}
+
+.hljs-variable,
+.hljs-template-variable {
+    color: #369;
+}
+
+.hljs-bullet {
+    color: #970;
+}
+
+.hljs-meta {
+    color: #34b;
+}
+
+.hljs-code,
+.hljs-number,
+.hljs-literal,
+.hljs-keyword,
+.hljs-selector-tag {
+    color: #099;
+}
+
+.hljs-regexp {
+    background-color: #fff0ff;
+    color: #808;
+}
+
+.hljs-symbol {
+    color: #990073;
+}
+
+.hljs-tag,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class {
+    color: #070;
+}

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -1,88 +1,9 @@
 /*
-Description: Foundation 4 docs style for highlight.js
-Author: Dan Allen <dan.j.allen@gmail.com>
-Website: http://foundation.zurb.com/docs/
-Version: 1.0
-Date: 2013-04-02
+----------------------------------------------------------------------------
+Copyright (c) 2016--, QIIME development team.
+
+Distributed under the terms of the Modified BSD License.
+
+The full license is in the file LICENSE, distributed with this software.
+----------------------------------------------------------------------------
 */
-
-.hljs {
-    display: block;
-    overflow-x: auto;
-    padding: 0.5em;
-    color: black;
-}
-
-.hljs-link,
-.hljs-emphasis,
-.hljs-attribute,
-.hljs-addition {
-    color: #070;
-}
-
-.hljs-emphasis {
-    font-style: italic;
-}
-
-.hljs-strong,
-.hljs-string,
-.hljs-deletion {
-    color: #d14;
-}
-
-.hljs-strong {
-    font-weight: bold;
-}
-
-.hljs-quote,
-.hljs-comment {
-    color: #998;
-    font-style: italic;
-}
-
-.hljs-section,
-.hljs-title {
-    color: #900;
-}
-
-.hljs-class .hljs-title,
-.hljs-type {
-    color: #458;
-}
-
-.hljs-variable,
-.hljs-template-variable {
-    color: #369;
-}
-
-.hljs-bullet {
-    color: #970;
-}
-
-.hljs-meta {
-    color: #34b;
-}
-
-.hljs-code,
-.hljs-number,
-.hljs-literal,
-.hljs-keyword,
-.hljs-selector-tag {
-    color: #099;
-}
-
-.hljs-regexp {
-    background-color: #fff0ff;
-    color: #808;
-}
-
-.hljs-symbol {
-    color: #990073;
-}
-
-.hljs-tag,
-.hljs-name,
-.hljs-selector-id,
-.hljs-selector-class {
-    color: #070;
-}

--- a/app/index.html
+++ b/app/index.html
@@ -1,3 +1,13 @@
+<!--
+----------------------------------------------------------------------------
+Copyright (c) 2016--, QIIME development team.
+
+Distributed under the terms of the Modified BSD License.
+
+The full license is in the file LICENSE, distributed with this software.
+----------------------------------------------------------------------------
+-->
+
 <!DOCTYPE html>
 <html>
   <head>

--- a/app/js/actions/artifacts.js
+++ b/app/js/actions/artifacts.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import actions from './';
 import { fetchAPI } from '../util/auth';
 

--- a/app/js/actions/connection.js
+++ b/app/js/actions/connection.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { remote } from 'electron';
 
 import actions from './';

--- a/app/js/actions/currentdirectory.js
+++ b/app/js/actions/currentdirectory.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { remote } from 'electron';
 
 import { refreshArtifacts, refreshVisualizations, refreshMetadata } from './artifacts';

--- a/app/js/actions/index.js
+++ b/app/js/actions/index.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import * as artifactActionCreators from './artifacts';
 import * as jobsActionCreators from './jobs';
 import * as pluginActionCreators from './plugins';

--- a/app/js/actions/jobs.js
+++ b/app/js/actions/jobs.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import actions from '../actions';
 import { fetchAPI } from '../util/auth';
 

--- a/app/js/actions/plugins.js
+++ b/app/js/actions/plugins.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { fetchAPI } from '../util/auth';
 import actions from './';
 

--- a/app/js/actions/tabstate.js
+++ b/app/js/actions/tabstate.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 export const changeTab = (name, index) => ({
     type: 'CHANGE_TAB',
     name,

--- a/app/js/actions/types.js
+++ b/app/js/actions/types.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { fetchAPI } from '../util/auth';
 
 

--- a/app/js/actions/windowstate.js
+++ b/app/js/actions/windowstate.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { fetchAPI } from '../util/auth';
 
 const clearWindowStateWithId = (id) => ({

--- a/app/js/components/Artifact.jsx
+++ b/app/js/components/Artifact.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 const Artifact = ({ data, onClick, deleteThis }) => (

--- a/app/js/components/ArtifactDetail.jsx
+++ b/app/js/components/ArtifactDetail.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 import JobHistoryData from './JobHistoryData';

--- a/app/js/components/ArtifactGenerator.jsx
+++ b/app/js/components/ArtifactGenerator.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 const style = { verticalAlign: 'middle' };

--- a/app/js/components/Artifacts.jsx
+++ b/app/js/components/Artifacts.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 import { ipcRenderer as ipc } from 'electron';
 

--- a/app/js/components/ArtifactsListFrame.jsx
+++ b/app/js/components/ArtifactsListFrame.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 import Artifacts from './Artifacts';

--- a/app/js/components/Directory.jsx
+++ b/app/js/components/Directory.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 const Directory = ({ path, dispatchChangeDirectory }) => (

--- a/app/js/components/JobHistory.jsx
+++ b/app/js/components/JobHistory.jsx
@@ -1,8 +1,17 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 import { highlightBlock } from 'highlight.js';
 import ReactMarkdown from 'react-markdown';
 
 import JobHistoryData from './JobHistoryData';
+import '!style-loader!css-loader!../../css/hljs.css';
 import style from '../../css/JobHistory.css';
 
 

--- a/app/js/components/JobHistoryData.jsx
+++ b/app/js/components/JobHistoryData.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 import style from '../../css/JobHistory.css';

--- a/app/js/components/JobList.jsx
+++ b/app/js/components/JobList.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 import { ipcRenderer as ipc } from 'electron';
 

--- a/app/js/components/JobListFrame.jsx
+++ b/app/js/components/JobListFrame.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 import JobList from './JobList';

--- a/app/js/components/JobRow.jsx
+++ b/app/js/components/JobRow.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 import Timer from './Timer';
 import moment from 'moment';

--- a/app/js/components/JobRunning.jsx
+++ b/app/js/components/JobRunning.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 import style from '../../css/JobRunning.css';

--- a/app/js/components/Loading.jsx
+++ b/app/js/components/Loading.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 import style from '../../css/Loading.css';

--- a/app/js/components/Metadata.jsx
+++ b/app/js/components/Metadata.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 import { shell } from 'electron';
 

--- a/app/js/components/MetadataFile.jsx
+++ b/app/js/components/MetadataFile.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 const MetadataFile = ({ data }) => (

--- a/app/js/components/Plugins.jsx
+++ b/app/js/components/Plugins.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 import Workflows from '../containers/Workflows';

--- a/app/js/components/Tabs.jsx
+++ b/app/js/components/Tabs.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 

--- a/app/js/components/Timer.jsx
+++ b/app/js/components/Timer.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 import moment from 'moment';
 

--- a/app/js/components/Visualization.jsx
+++ b/app/js/components/Visualization.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 import style from '../../css/Visualization.css';

--- a/app/js/components/Workflow.jsx
+++ b/app/js/components/Workflow.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 const Workflow = ({ flow, onClick, disabled }) => (

--- a/app/js/components/Workflows.jsx
+++ b/app/js/components/Workflows.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 import Workflow from './Workflow';

--- a/app/js/components/pages/App.jsx
+++ b/app/js/components/pages/App.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 import ArtifactsList from '../../containers/ArtifactsList';

--- a/app/js/components/pages/Job.jsx
+++ b/app/js/components/pages/Job.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 
 import _ from 'lodash';

--- a/app/js/containers/ArtifactDetail.js
+++ b/app/js/containers/ArtifactDetail.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { connect } from 'react-redux';
 
 import ArtifactDetail from '../components/ArtifactDetail';

--- a/app/js/containers/ArtifactGenerator.js
+++ b/app/js/containers/ArtifactGenerator.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { connect } from 'react-redux';
 
 import actions from '../actions';

--- a/app/js/containers/ArtifactsList.js
+++ b/app/js/containers/ArtifactsList.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { connect } from 'react-redux';
 
 import ArtifactsListFrame from '../components/ArtifactsListFrame';

--- a/app/js/containers/Auth.js
+++ b/app/js/containers/Auth.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';

--- a/app/js/containers/Directory.js
+++ b/app/js/containers/Directory.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { connect } from 'react-redux';
 
 import Directory from '../components/Directory';

--- a/app/js/containers/Job.js
+++ b/app/js/containers/Job.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { remote } from 'electron';

--- a/app/js/containers/JobHistory.js
+++ b/app/js/containers/JobHistory.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { connect } from 'react-redux';
 
 import JobHistory from '../components/JobHistory';

--- a/app/js/containers/JobList.js
+++ b/app/js/containers/JobList.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { connect } from 'react-redux';
 
 import actions from '../actions';

--- a/app/js/containers/Loading.js
+++ b/app/js/containers/Loading.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { connect } from 'react-redux';
 
 import Loading from '../components/Loading';

--- a/app/js/containers/PluginsList.js
+++ b/app/js/containers/PluginsList.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { connect } from 'react-redux';
 
 import Plugins from '../components/Plugins.jsx';

--- a/app/js/containers/Visualization.js
+++ b/app/js/containers/Visualization.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { connect } from 'react-redux';
 import { remote } from 'electron';
 

--- a/app/js/containers/Workflows.js
+++ b/app/js/containers/Workflows.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { ipcRenderer as ipc } from 'electron';

--- a/app/js/main.jsx
+++ b/app/js/main.jsx
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 import { render } from 'react-dom';
 import { createStore, applyMiddleware, compose } from 'redux';
@@ -20,7 +28,6 @@ import JobRunning from './components/JobRunning';
 import actions from './actions';
 
 import '!style-loader!css-loader!bootstrap-css-only';
-import '!style-loader!css-loader!../css/main.css';
 
 
 const enhancerSettings = {

--- a/app/js/reducers/artifacts.js
+++ b/app/js/reducers/artifacts.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 const initialState = {
     artifacts: [],
     visualizations: [],

--- a/app/js/reducers/connection.js
+++ b/app/js/reducers/connection.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 const initialState = {};
 
 const connectionReducer = (state = initialState, action) => {

--- a/app/js/reducers/currentdirectory.js
+++ b/app/js/reducers/currentdirectory.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 // remote.app.getPath('home') breaks redux-electron-store/webpack as the
 // renderer side is trying to be imported into the main process code
 const initialState = '';

--- a/app/js/reducers/currentjob.js
+++ b/app/js/reducers/currentjob.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 const initialState = {};
 
 const reducer = (state = initialState, action) => {

--- a/app/js/reducers/index.js
+++ b/app/js/reducers/index.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { combineReducers } from 'redux';
 import { routerReducer as routing } from 'react-router-redux';
 

--- a/app/js/reducers/jobs.js
+++ b/app/js/reducers/jobs.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 const initialState = {
     activeJobs: [],
     completedJobs: [],

--- a/app/js/reducers/plugins.js
+++ b/app/js/reducers/plugins.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 const initialState = [];
 
 const addMethod = (plugin, method) => {

--- a/app/js/reducers/supertypes.js
+++ b/app/js/reducers/supertypes.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import deepFreeze from 'deep-freeze';
 
 const initialState = {

--- a/app/js/reducers/tabstate.js
+++ b/app/js/reducers/tabstate.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { combineReducers } from 'redux';
 
 

--- a/app/js/reducers/windowState.js
+++ b/app/js/reducers/windowState.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 const initialState = {};
 
 const reducer = (state = initialState, action) => {

--- a/app/js/util/auth.js
+++ b/app/js/util/auth.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import CryptoJS from 'crypto-js';
 
 const makeB64Digest = (secretKey, httpVerb, url, requestTime, body) => {

--- a/app/js/util/devtools.js
+++ b/app/js/util/devtools.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import React from 'react';
 import { createDevTools } from 'redux-devtools';
 import LogMonitor from 'redux-devtools-log-monitor';

--- a/app/main.js
+++ b/app/main.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import { spawn } from 'child_process';
 import { app, BrowserWindow, ipcMain as ipc } from 'electron';
 import path from 'path';

--- a/config/eslint.yaml
+++ b/config/eslint.yaml
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 # See style guide: https://github.com/airbnb/javascript
 extends: airbnb
 

--- a/config/stylelint.yaml
+++ b/config/stylelint.yaml
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 extends: stylelint-config-standard
 rules:
     # PEP8 uses 4 spaces, it's just easier this way.

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const extendConfig = require('./webpack.shared');

--- a/config/webpack.main.config.js
+++ b/config/webpack.main.config.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 const path = require('path');
 const webpack = require('webpack');
 const extendConfig = require('./webpack.shared');

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');

--- a/config/webpack.shared.js
+++ b/config/webpack.shared.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const autoprefixer = require('autoprefixer');

--- a/qiime_studio/__init__.py
+++ b/qiime_studio/__init__.py
@@ -6,8 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-__version__ = "0.0.1"
-
 from .server import start_server
+__version__ = "0.0.1"
 
 __all__ = ['start_server']

--- a/qiime_studio/__main__.py
+++ b/qiime_studio/__main__.py
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 from qiime_studio import start_server
 
 # Allows `python -m qiime_studio` to start the server. This avoids polluting

--- a/qiime_studio/api/__init__.py
+++ b/qiime_studio/api/__init__.py
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 from .jobs import jobs
 from .plugins import plugins
 from .types import types

--- a/qiime_studio/api/jobs.py
+++ b/qiime_studio/api/jobs.py
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 import collections
 import io
 import sys

--- a/qiime_studio/api/plugins.py
+++ b/qiime_studio/api/plugins.py
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 import collections
 
 from flask import Blueprint, jsonify, url_for

--- a/qiime_studio/api/types.py
+++ b/qiime_studio/api/types.py
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 from flask import Blueprint, jsonify, request
 import qiime.sdk
 

--- a/qiime_studio/api/workspace.py
+++ b/qiime_studio/api/workspace.py
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 import os
 import glob
 import tempfile

--- a/qiime_studio/headers.py
+++ b/qiime_studio/headers.py
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 def add_cors_headers(response):
     response.headers.add('Access-Control-Allow-Headers',
                          'Authorization, Content-Type, '

--- a/qiime_studio/security.py
+++ b/qiime_studio/security.py
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 import hmac
 import base64
 from time import time

--- a/qiime_studio/server.py
+++ b/qiime_studio/server.py
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 import os
 import sys
 import base64

--- a/qiime_studio/util.py
+++ b/qiime_studio/util.py
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 import os
 import sys
 from contextlib import contextmanager

--- a/test/reducer_spec.js
+++ b/test/reducer_spec.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 /* eslint-disable no-unused-expressions*/
 /* global describe it */
 import { expect } from 'chai';

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016--, QIIME development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
 import chai from 'chai';
 import chaiThings from 'chai-things';
 


### PR DESCRIPTION
I'd like to thank `sed` for this one... 84 files in less than a few minutes.

```bash
find app/ -type f -name '*.js*' -execdir sed -i -e '1i\
// ----------------------------------------------------------------------------\
// Copyright (c) 2016--, QIIME development team.\
//\
// Distributed under the terms of the Modified BSD License.\
//\
// The full license is in the file LICENSE, distributed with this software.\
// ----------------------------------------------------------------------------\
\
' {} \;
```

Resolves #64