### PR TITLE
MAINT: support for new "actions" API `Results` type

### DIFF
--- a/qiime_studio/api/jobs.py
+++ b/qiime_studio/api/jobs.py
@@ -136,7 +136,7 @@ def _callback_factory(job_id, outputs, stdout_fh, stderr_fh):
         now = int(time.time() * 1000)
         try:
             results = future.result()
-            if type(results) is not tuple:
+            if not isinstance(results, tuple):
                 results = (results,)
         except Exception:
             results = None


### PR DESCRIPTION
The results tuple type-check was too specific.